### PR TITLE
Add App Intents action catalog + full Siri integration for guests

### DIFF
--- a/App/Intents/GuestActionIntents.swift
+++ b/App/Intents/GuestActionIntents.swift
@@ -1,0 +1,80 @@
+import AppIntents
+import ReeveModels
+
+/// User-facing error when a guest can't be addressed (server not synced, secret
+/// missing, offline).
+enum ReeveIntentError: Error, CustomLocalizedStringResourceConvertible {
+    case unavailable
+
+    var localizedStringResource: LocalizedStringResource {
+        "That guest isn't reachable right now. Open Reeve, make sure the server is added, and try again."
+    }
+}
+
+private enum GuestPower {
+    static func run(
+        _ action: PowerAction, guest: GuestEntity, provider: ProxmoxIntentProvider
+    ) async throws {
+        guard let t = provider.target(for: guest) else { throw ReeveIntentError.unavailable }
+        _ = try await provider.api.power(t.conn, node: t.node, kind: t.kind, vmid: t.vmid, action: action)
+    }
+}
+
+struct StartGuestIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Guest"
+    static let description = IntentDescription("Start a VM or container in your homelab.")
+
+    @Parameter(title: "Guest") var guest: GuestEntity
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await GuestPower.run(.start, guest: guest, provider: provider)
+        return .result(dialog: "Starting \(guest.name).")
+    }
+}
+
+struct RebootGuestIntent: AppIntent {
+    static let title: LocalizedStringResource = "Reboot Guest"
+    static let description = IntentDescription("Reboot a VM or container.")
+    // Force a fresh Face ID / Touch ID / passcode check before the reboot runs.
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @Parameter(title: "Guest") var guest: GuestEntity
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation(result: .result(dialog: "Reboot \(guest.name)?"))
+        try await GuestPower.run(.reboot, guest: guest, provider: provider)
+        return .result(dialog: "Rebooting \(guest.name).")
+    }
+}
+
+struct ShutdownGuestIntent: AppIntent {
+    static let title: LocalizedStringResource = "Shut Down Guest"
+    static let description = IntentDescription("Gracefully shut down a VM or container.")
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @Parameter(title: "Guest") var guest: GuestEntity
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation(result: .result(dialog: "Shut down \(guest.name)?"))
+        try await GuestPower.run(.shutdown, guest: guest, provider: provider)
+        return .result(dialog: "Shutting down \(guest.name).")
+    }
+}
+
+struct StopGuestIntent: AppIntent {
+    static let title: LocalizedStringResource = "Stop Guest"
+    static let description = IntentDescription("Force-stop (power off) a VM or container.")
+    static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @Parameter(title: "Guest") var guest: GuestEntity
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        try await requestConfirmation(result: .result(dialog: "Stop \(guest.name)? This powers it off immediately."))
+        try await GuestPower.run(.stop, guest: guest, provider: provider)
+        return .result(dialog: "\(guest.name) stopped.")
+    }
+}

--- a/App/Intents/GuestActionIntents.swift
+++ b/App/Intents/GuestActionIntents.swift
@@ -5,18 +5,45 @@ import ReeveModels
 /// missing, offline).
 enum ReeveIntentError: Error, CustomLocalizedStringResourceConvertible {
     case unavailable
+    case noGuests
+    case message(LocalizedStringResource)
 
     var localizedStringResource: LocalizedStringResource {
-        "That guest isn't reachable right now. Open Reeve, make sure the server is added, and try again."
+        switch self {
+        case .unavailable:
+            "That guest isn't reachable right now. Open Reeve, make sure the server is added, and try again."
+        case .noGuests:
+            "No guests are available. Open Reeve and add a server first."
+        case .message(let text):
+            text
+        }
     }
 }
 
-private enum GuestPower {
+nonisolated enum GuestPower {
     static func run(
         _ action: PowerAction, guest: GuestEntity, provider: ProxmoxIntentProvider
     ) async throws {
         guard let t = provider.target(for: guest) else { throw ReeveIntentError.unavailable }
         _ = try await provider.api.power(t.conn, node: t.node, kind: t.kind, vmid: t.vmid, action: action)
+    }
+
+    /// Guests to offer for disambiguation when the user didn't name one. We only
+    /// return guests the action actually applies to (stopped for Start, running
+    /// for Stop/etc.) and deliberately do NOT fall back to all guests: offering a
+    /// running guest for "Start" would issue a no-op the success dialog still
+    /// reports as done. If nothing is in the right state we throw a clear,
+    /// action-specific message instead of an empty or misleading prompt.
+    static func pool(
+        _ provider: ProxmoxIntentProvider,
+        matching keep: (GuestEntity) -> Bool,
+        whenNoneMatch message: LocalizedStringResource
+    ) async throws -> [GuestEntity] {
+        let all = await provider.allGuests()
+        guard !all.isEmpty else { throw ReeveIntentError.noGuests }
+        let pool = all.filter(keep)
+        guard !pool.isEmpty else { throw ReeveIntentError.message(message) }
+        return pool
     }
 }
 
@@ -24,12 +51,21 @@ struct StartGuestIntent: AppIntent {
     static let title: LocalizedStringResource = "Start Guest"
     static let description = IntentDescription("Start a VM or container in your homelab.")
 
-    @Parameter(title: "Guest") var guest: GuestEntity
+    @Parameter(title: "Guest") var guest: GuestEntity?
     @Dependency var provider: ProxmoxIntentProvider
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        try await GuestPower.run(.start, guest: guest, provider: provider)
-        return .result(dialog: "Starting \(guest.name).")
+        let target: GuestEntity
+        if let guest {
+            target = guest
+        } else {
+            let pool = try await GuestPower.pool(
+                provider, matching: { $0.status == .stopped },
+                whenNoneMatch: "Every guest is already running.")
+            target = try await $guest.requestDisambiguation(among: pool, dialog: "Which guest do you want to start?")
+        }
+        try await GuestPower.run(.start, guest: target, provider: provider)
+        return .result(dialog: "Starting \(target.name).")
     }
 }
 
@@ -39,13 +75,22 @@ struct RebootGuestIntent: AppIntent {
     // Force a fresh Face ID / Touch ID / passcode check before the reboot runs.
     static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
-    @Parameter(title: "Guest") var guest: GuestEntity
+    @Parameter(title: "Guest") var guest: GuestEntity?
     @Dependency var provider: ProxmoxIntentProvider
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        try await requestConfirmation(result: .result(dialog: "Reboot \(guest.name)?"))
-        try await GuestPower.run(.reboot, guest: guest, provider: provider)
-        return .result(dialog: "Rebooting \(guest.name).")
+        let target: GuestEntity
+        if let guest {
+            target = guest
+        } else {
+            let pool = try await GuestPower.pool(
+                provider, matching: { $0.status == .running },
+                whenNoneMatch: "No guests are running right now.")
+            target = try await $guest.requestDisambiguation(among: pool, dialog: "Which guest do you want to reboot?")
+        }
+        try await requestConfirmation(result: .result(dialog: "Reboot \(target.name)?"))
+        try await GuestPower.run(.reboot, guest: target, provider: provider)
+        return .result(dialog: "Rebooting \(target.name).")
     }
 }
 
@@ -54,13 +99,22 @@ struct ShutdownGuestIntent: AppIntent {
     static let description = IntentDescription("Gracefully shut down a VM or container.")
     static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
-    @Parameter(title: "Guest") var guest: GuestEntity
+    @Parameter(title: "Guest") var guest: GuestEntity?
     @Dependency var provider: ProxmoxIntentProvider
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        try await requestConfirmation(result: .result(dialog: "Shut down \(guest.name)?"))
-        try await GuestPower.run(.shutdown, guest: guest, provider: provider)
-        return .result(dialog: "Shutting down \(guest.name).")
+        let target: GuestEntity
+        if let guest {
+            target = guest
+        } else {
+            let pool = try await GuestPower.pool(
+                provider, matching: { $0.status == .running },
+                whenNoneMatch: "No guests are running right now.")
+            target = try await $guest.requestDisambiguation(among: pool, dialog: "Which guest do you want to shut down?")
+        }
+        try await requestConfirmation(result: .result(dialog: "Shut down \(target.name)?"))
+        try await GuestPower.run(.shutdown, guest: target, provider: provider)
+        return .result(dialog: "Shutting down \(target.name).")
     }
 }
 
@@ -69,12 +123,21 @@ struct StopGuestIntent: AppIntent {
     static let description = IntentDescription("Force-stop (power off) a VM or container.")
     static let authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
-    @Parameter(title: "Guest") var guest: GuestEntity
+    @Parameter(title: "Guest") var guest: GuestEntity?
     @Dependency var provider: ProxmoxIntentProvider
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        try await requestConfirmation(result: .result(dialog: "Stop \(guest.name)? This powers it off immediately."))
-        try await GuestPower.run(.stop, guest: guest, provider: provider)
-        return .result(dialog: "\(guest.name) stopped.")
+        let target: GuestEntity
+        if let guest {
+            target = guest
+        } else {
+            let pool = try await GuestPower.pool(
+                provider, matching: { $0.status == .running },
+                whenNoneMatch: "No guests are running right now.")
+            target = try await $guest.requestDisambiguation(among: pool, dialog: "Which guest do you want to stop?")
+        }
+        try await requestConfirmation(result: .result(dialog: "Stop \(target.name)? This powers it off immediately."))
+        try await GuestPower.run(.stop, guest: target, provider: provider)
+        return .result(dialog: "\(target.name) stopped.")
     }
 }

--- a/App/Intents/GuestEntity.swift
+++ b/App/Intents/GuestEntity.swift
@@ -1,0 +1,121 @@
+import AppIntents
+import ReeveModels
+import ReevePersistence
+
+/// VM vs container, as an App Intents enum so it shows nicely in Shortcuts/Siri.
+enum GuestKindOption: String, AppEnum {
+    case vm
+    case container
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Guest Kind" }
+    static var caseDisplayRepresentations: [GuestKindOption: DisplayRepresentation] {
+        [.vm: "Virtual Machine", .container: "Container"]
+    }
+
+    var guestKind: GuestKind { self == .container ? .lxc : .qemu }
+}
+
+/// Whether a guest is running, for status display and Find-guests filtering.
+enum GuestRunState: String, AppEnum {
+    case running
+    case stopped
+    case unknown
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Status" }
+    static var caseDisplayRepresentations: [GuestRunState: DisplayRepresentation] {
+        [.running: "Running", .stopped: "Stopped", .unknown: "Unknown"]
+    }
+
+    var label: String { rawValue.capitalized }
+}
+
+/// A VM or LXC container exposed to Siri / Shortcuts / Spotlight. The `id` encodes
+/// everything needed to address it (`profileID|node|kind|vmid`) so an action can
+/// run from just the id, even if a live lookup fails.
+struct GuestEntity: AppEntity, Identifiable {
+    let id: String
+    let profileID: String
+    let node: String
+    let vmid: Int
+    let kind: GuestKindOption
+    let name: String
+    let status: GuestRunState
+    let cpuPercent: Double
+    let serverName: String
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation { "Guest" }
+    static var defaultQuery: GuestQuery { GuestQuery() }
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(name)",
+            subtitle: "\(serverName) · \(status.label) · \(Int(cpuPercent))% CPU",
+            image: .init(systemName: kind == .container ? "shippingbox" : "desktopcomputer")
+        )
+    }
+
+    init(
+        id: String, profileID: String, node: String, vmid: Int, kind: GuestKindOption,
+        name: String, status: GuestRunState, cpuPercent: Double, serverName: String
+    ) {
+        self.id = id
+        self.profileID = profileID
+        self.node = node
+        self.vmid = vmid
+        self.kind = kind
+        self.name = name
+        self.status = status
+        self.cpuPercent = cpuPercent
+        self.serverName = serverName
+    }
+
+    /// Build from a live cluster-resource row. Returns nil for non-guests/templates.
+    init?(resource r: ClusterResource, profile: ServerProfile) {
+        guard let node = r.node, let vmid = r.vmid,
+              r.type == .qemu || r.type == .lxc, !r.isTemplate else { return nil }
+        let kind: GuestKindOption = r.type == .lxc ? .container : .vm
+        let status: GuestRunState
+        switch r.status {
+        case .some(.running), .some(.online): status = .running
+        case .some(.stopped), .some(.offline): status = .stopped
+        default: status = .unknown   // nil or an indeterminate/transient state
+        }
+        self.init(
+            id: GuestEntity.makeID(profile: profile.id.uuidString, node: node, kind: kind, vmid: vmid),
+            profileID: profile.id.uuidString,
+            node: node,
+            vmid: vmid,
+            kind: kind,
+            name: r.displayName,
+            status: status,
+            cpuPercent: (r.cpu ?? 0) * 100,
+            serverName: profile.name
+        )
+    }
+
+    static func makeID(profile: String, node: String, kind: GuestKindOption, vmid: Int) -> String {
+        // Encode the Proxmox kind ("qemu"/"lxc") so the id round-trips through
+        // `reconstruct(id:)` and stays stable if the UI enum is ever renamed.
+        "\(profile)|\(node)|\(kind.guestKind.rawValue)|\(vmid)"
+    }
+}
+
+/// Resolves guests by id (for saved shortcuts) and by spoken name (so "Restart
+/// Plex" finds the Plex guest). Backed by the shared `ProxmoxIntentProvider`.
+struct GuestQuery: EntityStringQuery {
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func entities(for identifiers: [String]) async throws -> [GuestEntity] {
+        let all = await provider.allGuests()
+        let byID = Dictionary(all.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        return identifiers.compactMap { byID[$0] ?? provider.reconstruct(id: $0) }
+    }
+
+    func suggestedEntities() async throws -> [GuestEntity] {
+        await provider.allGuests()
+    }
+
+    func entities(matching string: String) async throws -> [GuestEntity] {
+        await provider.allGuests().filter { $0.name.localizedCaseInsensitiveContains(string) }
+    }
+}

--- a/App/Intents/GuestQueryIntents.swift
+++ b/App/Intents/GuestQueryIntents.swift
@@ -11,7 +11,12 @@ struct GuestStatusIntent: AppIntent {
 
     func perform() async throws -> some IntentResult & ReturnsValue<GuestEntity> & ProvidesDialog {
         let fresh = (await provider.allGuests()).first { $0.id == guest.id } ?? guest
-        let dialog: IntentDialog = "\(fresh.name) is \(fresh.status.label), \(Int(fresh.cpuPercent)) percent CPU."
+        // `full` is read aloud on voice-only devices (HomePod/AirPods/CarPlay);
+        // `supporting` is the shorter line shown next to on-screen UI.
+        let dialog = IntentDialog(
+            full: "\(fresh.name) is \(fresh.status.label), \(Int(fresh.cpuPercent)) percent CPU.",
+            supporting: "\(fresh.status.label) · \(Int(fresh.cpuPercent))% CPU"
+        )
         return .result(value: fresh, dialog: dialog)
     }
 }
@@ -23,15 +28,24 @@ struct HomelabStatusIntent: AppIntent {
 
     @Dependency var provider: ProxmoxIntentProvider
 
-    func perform() async throws -> some IntentResult & ProvidesDialog {
+    func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         let guests = await provider.allGuests()
-        guard !guests.isEmpty else {
-            return .result(dialog: "No servers synced yet. Open Reeve to add one.")
-        }
         let up = guests.filter { $0.status == .running }.count
         let n = provider.serverCount
-        let dialog: IntentDialog = "\(up) of \(guests.count) guests running across \(n) server\(n == 1 ? "" : "s")."
-        return .result(dialog: dialog)
+        let servers = Dictionary(grouping: guests, by: \.serverName)
+            .map { HomelabSnippetView.Server(
+                name: $0.key,
+                up: $0.value.filter { $0.status == .running }.count,
+                total: $0.value.count) }
+            .sorted { $0.name < $1.name }
+        let dialog: IntentDialog = guests.isEmpty
+            ? IntentDialog(full: "No servers synced yet. Open Reeve to add one.", supporting: "No servers")
+            : IntentDialog(
+                full: "\(up) of \(guests.count) guests running across \(n) server\(n == 1 ? "" : "s").",
+                supporting: "\(up)/\(guests.count) running")
+        return .result(dialog: dialog) {
+            HomelabSnippetView(running: up, total: guests.count, servers: servers)
+        }
     }
 }
 

--- a/App/Intents/GuestQueryIntents.swift
+++ b/App/Intents/GuestQueryIntents.swift
@@ -1,0 +1,54 @@
+import AppIntents
+
+/// "Get Guest Status" — speaks a guest's state and returns the (refreshed) entity
+/// so it can chain into other Shortcuts actions.
+struct GuestStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Guest Status"
+    static let description = IntentDescription("Check a guest's status and CPU usage.")
+
+    @Parameter(title: "Guest") var guest: GuestEntity
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ReturnsValue<GuestEntity> & ProvidesDialog {
+        let fresh = (await provider.allGuests()).first { $0.id == guest.id } ?? guest
+        let dialog: IntentDialog = "\(fresh.name) is \(fresh.status.label), \(Int(fresh.cpuPercent)) percent CPU."
+        return .result(value: fresh, dialog: dialog)
+    }
+}
+
+/// "Homelab Status" — a quick spoken summary across every configured server.
+struct HomelabStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Homelab Status"
+    static let description = IntentDescription("Summarize how many guests are running across your servers.")
+
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let guests = await provider.allGuests()
+        guard !guests.isEmpty else {
+            return .result(dialog: "No servers synced yet. Open Reeve to add one.")
+        }
+        let up = guests.filter { $0.status == .running }.count
+        let n = provider.serverCount
+        let dialog: IntentDialog = "\(up) of \(guests.count) guests running across \(n) server\(n == 1 ? "" : "s")."
+        return .result(dialog: dialog)
+    }
+}
+
+/// "Find Guests" — returns a list (optionally filtered) that chains into actions,
+/// e.g. Find guests (Stopped) -> Repeat -> Start Guest.
+struct FindGuestsIntent: AppIntent {
+    static let title: LocalizedStringResource = "Find Guests"
+    static let description = IntentDescription("Find guests, optionally filtered by status or CPU usage.")
+
+    @Parameter(title: "Status") var status: GuestRunState?
+    @Parameter(title: "Minimum CPU Percent") var minCPU: Double?
+    @Dependency var provider: ProxmoxIntentProvider
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[GuestEntity]> {
+        var guests = await provider.allGuests()
+        if let status { guests = guests.filter { $0.status == status } }
+        if let minCPU { guests = guests.filter { $0.cpuPercent >= minCPU } }
+        return .result(value: guests)
+    }
+}

--- a/App/Intents/GuestSpotlight.swift
+++ b/App/Intents/GuestSpotlight.swift
@@ -1,0 +1,42 @@
+#if canImport(CoreSpotlight)
+import AppIntents
+import CoreSpotlight
+import UniformTypeIdentifiers
+
+/// Index individual guests into Spotlight so they show up (with semantic search)
+/// when the user searches the home screen. iOS 18 / macOS 15 feature.
+@available(iOS 18.0, macOS 15.0, *)
+extension GuestEntity: IndexedEntity {
+    var attributeSet: CSSearchableItemAttributeSet {
+        let attrs = CSSearchableItemAttributeSet(contentType: .content)
+        attrs.title = name
+        attrs.contentDescription = "\(serverName) · \(status.label) · \(Int(cpuPercent))% CPU"
+        attrs.keywords = [serverName, kind == .container ? "container" : "VM", status.rawValue, "proxmox"]
+        return attrs
+    }
+}
+
+@available(iOS 18.0, macOS 15.0, *)
+enum GuestSpotlightIndexer {
+    private static let indexedIDsKey = "spotlight.indexedGuestIDs"
+
+    /// Refresh the Spotlight index from the current set of guests, pruning any
+    /// guests that no longer exist (deleted VM, removed server, rename) so stale
+    /// entries don't linger and then fail when tapped.
+    static func reindex() async {
+        let guests = await ProxmoxIntentProvider().allGuests()
+        let index = CSSearchableIndex.default()
+        let current = Set(guests.map(\.id))
+        let previous = Set(UserDefaults.standard.stringArray(forKey: indexedIDsKey) ?? [])
+
+        let removed = previous.subtracting(current)
+        if !removed.isEmpty {
+            try? await index.deleteAppEntities(identifiedBy: Array(removed), ofType: GuestEntity.self)
+        }
+        if !guests.isEmpty {
+            try? await index.indexAppEntities(guests)
+        }
+        UserDefaults.standard.set(Array(current), forKey: indexedIDsKey)
+    }
+}
+#endif

--- a/App/Intents/HomelabSnippet.swift
+++ b/App/Intents/HomelabSnippet.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// The card Siri/Spotlight shows alongside the spoken "Homelab status" answer.
+/// Static (no buttons) so it works back to iOS 17; an interactive iOS-26 snippet
+/// with inline Start/Stop is a future enhancement.
+struct HomelabSnippetView: View {
+    struct Server: Identifiable {
+        let name: String
+        let up: Int
+        let total: Int
+        var id: String { name }
+        var tint: Color { up == total ? .green : (up == 0 ? .red : .yellow) }
+    }
+
+    let running: Int
+    let total: Int
+    let servers: [Server]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "server.rack").foregroundStyle(.tint)
+                Text("Homelab").font(.headline)
+                Spacer()
+                if total > 0 {
+                    Text("\(running)/\(total) running")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+            }
+            if servers.isEmpty {
+                Text("No servers synced yet. Open Reeve to add one.")
+                    .font(.subheadline).foregroundStyle(.secondary)
+            } else {
+                ForEach(servers) { server in
+                    HStack(spacing: 8) {
+                        Circle().fill(server.tint).frame(width: 8, height: 8)
+                        Text(server.name).font(.subheadline).lineLimit(1)
+                        Spacer()
+                        Text("\(server.up)/\(server.total)")
+                            .font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}

--- a/App/Intents/ProxmoxIntentProvider.swift
+++ b/App/Intents/ProxmoxIntentProvider.swift
@@ -1,0 +1,83 @@
+import Foundation
+import ReeveModels
+import ReeveNetworking
+import ReevePersistence
+
+/// Builds Proxmox connections off the main actor (App Intents run in the
+/// background), mirroring `ProfileStore.connection(for:)` without touching the
+/// `@MainActor` store. All inputs are `Sendable`.
+nonisolated struct IntentProfileResolver: Sendable {
+    private let keychain = KeychainStore()
+    private let storageKey = "homelab.serverProfiles"
+
+    func profiles() -> [ServerProfile] {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([ServerProfile].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    func profile(id: String) -> ServerProfile? {
+        profiles().first { $0.id.uuidString == id }
+    }
+
+    func connection(for profile: ServerProfile) -> ServerConnection? {
+        if profile.isDemo { return profile.connection(secret: "demo") }
+        guard let secret = keychain.secret(for: profile.id) else { return nil }
+        return profile.connection(secret: secret)
+    }
+}
+
+/// The App Intents dependency: a shared Proxmox client plus guest enumeration and
+/// connection resolution. Registered once in `ReeveApp.init` via
+/// `AppDependencyManager` so every intent/query reaches it with `@Dependency`.
+nonisolated final class ProxmoxIntentProvider: Sendable {
+    let api: ProxmoxAPI
+    private let resolver = IntentProfileResolver()
+
+    init(api: ProxmoxAPI = DemoProxmoxAPI(live: LiveProxmoxAPI())) {
+        self.api = api
+    }
+
+    var serverCount: Int { resolver.profiles().count }
+
+    /// Every non-template guest across all configured servers, as entities.
+    /// Servers are queried concurrently so one unreachable server can't blow the
+    /// App Intent's short time budget (a slow server only delays its own results).
+    func allGuests() async -> [GuestEntity] {
+        await withTaskGroup(of: [GuestEntity].self) { group in
+            for profile in resolver.profiles() {
+                group.addTask {
+                    guard let conn = self.resolver.connection(for: profile),
+                          let resources = try? await self.api.clusterResources(conn) else { return [] }
+                    return resources.compactMap { GuestEntity(resource: $0, profile: profile) }
+                }
+            }
+            var result: [GuestEntity] = []
+            for await chunk in group { result.append(contentsOf: chunk) }
+            return result
+        }
+    }
+
+    /// Resolve an entity to the connection + addressing an action needs.
+    func target(
+        for guest: GuestEntity
+    ) -> (conn: ServerConnection, node: String, kind: GuestKind, vmid: Int)? {
+        guard let profile = resolver.profile(id: guest.profileID),
+              let conn = resolver.connection(for: profile) else { return nil }
+        return (conn, guest.node, guest.kind.guestKind, guest.vmid)
+    }
+
+    /// Offline fallback: rebuild a minimal entity from its encoded id.
+    func reconstruct(id: String) -> GuestEntity? {
+        let parts = id.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 4, let vmid = Int(parts[3]) else { return nil }
+        let kind: GuestKindOption = parts[2] == "lxc" ? .container : .vm
+        let serverName = resolver.profile(id: parts[0])?.name ?? "Server"
+        return GuestEntity(
+            id: id, profileID: parts[0], node: parts[1], vmid: vmid, kind: kind,
+            name: "\(kind == .container ? "Container" : "VM") \(vmid)",
+            status: .unknown, cpuPercent: 0, serverName: serverName
+        )
+    }
+}

--- a/App/Intents/ReeveIntents.swift
+++ b/App/Intents/ReeveIntents.swift
@@ -23,18 +23,81 @@ struct ReeveStatusIntent: AppIntent {
     }
 }
 
-/// Surfaces the intent in the Shortcuts app, Spotlight, and Siri.
+/// The single App Shortcuts provider: every voice phrase Siri/Spotlight exposes.
+/// Each phrase MUST contain `\(.applicationName)`; Siri does not auto-synonym
+/// verbs, so we list the variants people actually say. Capped well under 10.
 struct ReeveShortcuts: AppShortcutsProvider {
+    @AppShortcutsBuilder
     static var appShortcuts: [AppShortcut] {
+        // Quick, cached, network-free status.
         AppShortcut(
             intent: ReeveStatusIntent(),
             phrases: [
                 "\(.applicationName) status",
                 "Check \(.applicationName)",
-                "How is my homelab in \(.applicationName)",
             ],
             shortTitle: "Reeve Status",
             systemImageName: "server.rack"
+        )
+        // Live summary across all servers.
+        AppShortcut(
+            intent: HomelabStatusIntent(),
+            phrases: [
+                "Homelab status in \(.applicationName)",
+                "How is my homelab in \(.applicationName)",
+                "Are my servers up in \(.applicationName)",
+            ],
+            shortTitle: "Homelab Status",
+            systemImageName: "checkmark.seal"
+        )
+        AppShortcut(
+            intent: StartGuestIntent(),
+            phrases: [
+                "Start \(\.$guest) in \(.applicationName)",
+                "Boot \(\.$guest) in \(.applicationName)",
+                "Power on \(\.$guest) in \(.applicationName)",
+                "Start a guest in \(.applicationName)",
+            ],
+            shortTitle: "Start Guest",
+            systemImageName: "play.fill"
+        )
+        AppShortcut(
+            intent: StopGuestIntent(),
+            phrases: [
+                "Stop \(\.$guest) in \(.applicationName)",
+                "Power off \(\.$guest) in \(.applicationName)",
+                "Stop a guest in \(.applicationName)",
+            ],
+            shortTitle: "Stop Guest",
+            systemImageName: "stop.fill"
+        )
+        AppShortcut(
+            intent: RebootGuestIntent(),
+            phrases: [
+                "Restart \(\.$guest) in \(.applicationName)",
+                "Reboot \(\.$guest) in \(.applicationName)",
+                "Reboot a guest in \(.applicationName)",
+            ],
+            shortTitle: "Reboot Guest",
+            systemImageName: "arrow.clockwise"
+        )
+        AppShortcut(
+            intent: ShutdownGuestIntent(),
+            phrases: [
+                "Shut down \(\.$guest) in \(.applicationName)",
+                "Shut down a guest in \(.applicationName)",
+            ],
+            shortTitle: "Shut Down Guest",
+            systemImageName: "moon.fill"
+        )
+        AppShortcut(
+            intent: GuestStatusIntent(),
+            phrases: [
+                "Status of \(\.$guest) in \(.applicationName)",
+                "How is \(\.$guest) in \(.applicationName)",
+            ],
+            shortTitle: "Guest Status",
+            systemImageName: "info.circle"
         )
     }
 }

--- a/App/ReeveApp.swift
+++ b/App/ReeveApp.swift
@@ -40,6 +40,9 @@ struct ReeveApp: App {
                 WatchConnectivityProvider.shared.start()
                 WatchConnectivityProvider.shared.sync(from: model.profiles)
                 #endif
+                // Tell Siri to re-query the guest list backing parameterized
+                // phrases (handles renamed/added/removed guests).
+                ReeveShortcuts.updateAppShortcutParameters()
                 // Refresh the Spotlight index of individual guests in the background.
                 if #available(iOS 18.0, macOS 15.0, *) {
                     Task.detached(priority: .utility) {

--- a/App/ReeveApp.swift
+++ b/App/ReeveApp.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import SwiftUI
 
 @main
@@ -10,6 +11,9 @@ struct ReeveApp: App {
         // Larger shared cache so service logos (AsyncImage) stay resident and don't
         // flicker/re-fetch while scrolling the Services list.
         URLCache.shared = URLCache(memoryCapacity: 50_000_000, diskCapacity: 200_000_000)
+        // App Intents (Siri/Shortcuts/Spotlight) reach the Proxmox client through
+        // this dependency; registered here so it resolves even on a background launch.
+        AppDependencyManager.shared.add(dependency: ProxmoxIntentProvider())
         // Register the agent's continued-processing task during launch (iOS 26+),
         // so a long-running setup keeps going after the user leaves the app.
         #if os(iOS)
@@ -36,6 +40,12 @@ struct ReeveApp: App {
                 WatchConnectivityProvider.shared.start()
                 WatchConnectivityProvider.shared.sync(from: model.profiles)
                 #endif
+                // Refresh the Spotlight index of individual guests in the background.
+                if #available(iOS 18.0, macOS 15.0, *) {
+                    Task.detached(priority: .utility) {
+                        await GuestSpotlightIndexer.reindex()
+                    }
+                }
             }
             .onChange(of: scenePhase) { _, phase in
                 switch phase {

--- a/App/Settings/SettingsView.swift
+++ b/App/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import ReeveModels
 import SwiftUI
 
@@ -75,6 +76,17 @@ struct SettingsView: View {
                 } footer: {
                     Text("Background checks are best-effort; iOS controls how often they run. A threshold of 0% is off.")
                 }
+
+                #if os(iOS)
+                Section {
+                    SiriTipView(intent: HomelabStatusIntent())
+                    ShortcutsLink()
+                } header: {
+                    Text("Siri & Shortcuts")
+                } footer: {
+                    Text("Say things like \u{201C}Homelab status\u{201D} or \u{201C}Start [guest] in Reeve.\u{201D} Tap to add or customize phrases in the Shortcuts app.")
+                }
+                #endif
 
                 Section {
                     LabeledContent("Version", value: appVersion)

--- a/App/Views/Guests/GuestDetailView.swift
+++ b/App/Views/Guests/GuestDetailView.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import Charts
 import ReeveFeatures
 import ReeveModels
@@ -66,6 +67,9 @@ struct GuestDetailView: View {
                     }
                 }
                 .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+                #if os(iOS)
+                SiriTipView(intent: StartGuestIntent())
+                #endif
                 if let model {
                     timeframePicker(model)
                     CPUChart(points: model.history)

--- a/AppInfo.plist
+++ b/AppInfo.plist
@@ -11,6 +11,18 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).agent.*</string>
 	</array>
+	<!-- Alternate app names + pronunciation hints so Siri still recognizes the app
+	     when "Reeve" is misheard. Used automatically by every `\(.applicationName)`
+	     phrase. Max 3 entries; must not repeat the real display name. -->
+	<key>INAlternativeAppNames</key>
+	<array>
+		<dict>
+			<key>INAlternativeAppName</key>
+			<string>Homelab</string>
+			<key>INAlternativeAppNamePronunciationHint</key>
+			<string>home lab</string>
+		</dict>
+	</array>
 	<!-- Export compliance. The app's encryption is treated as exempt: HTTPS/TLS to
 	     the Proxmox API and an SSH secure channel (Citadel) for the remote console,
 	     all using standard published algorithms with no proprietary cryptography.


### PR DESCRIPTION
## Summary

Adds an **App Intents action catalog** plus **full Siri integration** so Proxmox guests are usable hands-free from **Siri**, the **Shortcuts app**, and **Spotlight**.

### Entity & resolution
- `GuestEntity` (AppEntity) for any VM/container, resolvable by id (for saved shortcuts) and by spoken name (so "Restart Plex" finds the Plex guest). The id encodes `profileID|node|kind|vmid` so an action can run from the id alone, even offline.
- `GuestQuery` provides `suggestedEntities()`, which backs the parameterized voice phrases.

### Action intents
- `Start`, `Stop`, `Reboot`, `Shut Down` — call the existing `ProxmoxAPI.power`. The three disruptive ones are gated by **biometric auth** (`authenticationPolicy = .requiresLocalDeviceAuthentication`) **and a confirmation prompt**.
- The guest parameter is **optional**: when unnamed (e.g. "Start a guest in Reeve"), the intent disambiguates among only the guests the action applies to (stopped for Start, running for the rest), and throws a clear action-specific message ("Every guest is already running.") when nothing qualifies, instead of offering a no-op target.

### Query intents
- `Get Guest Status` — returns the refreshed entity (chainable) plus a spoken summary.
- `Homelab Status` — "X of Y guests running across N servers," with a **snippet card** showing per-server breakdown alongside the spoken answer.
- `Find Guests` — filter by status / minimum CPU, returns a chainable list (e.g. **Find stopped guests → Start each**).

### Siri integration
- `ReeveShortcuts` (AppShortcutsProvider): **7 zero-config App Shortcuts** with verb-variant phrases, each carrying the required `applicationName` token. Parameterized ("Start [guest] in Reeve") and no-parameter ("Start a guest in Reeve") phrases coexist per Apple's documented pattern.
- `INAlternativeAppNames` synonym + pronunciation hint for Siri recognition.
- Voice-tuned `IntentDialog(full:supporting:)` (full line read aloud on HomePod/AirPods/CarPlay, supporting line shown on screen).
- In-app `SiriTipView` + `ShortcutsLink` in Settings and a SiriTip on guest detail (iOS-gated); `updateAppShortcutParameters()` on launch.

### Plumbing
- A `nonisolated`, `Sendable` `ProxmoxIntentProvider` (registered via `AppDependencyManager` in `ReeveApp.init`) builds connections off the main actor, mirroring `ProfileStore.connection`. Servers are queried **concurrently** so one slow server can't exhaust the intent's time budget.
- Individual guests are indexed into **Spotlight** (iOS 18+), pruning stale entries on each refresh.

## Review

Reviewed with `/code-review` (high) across two passes:
- **Catalog:** fixed a critical id round-trip bug (kind encoded as `vm`/`container` but decoded against `lxc`), Spotlight pruning of deleted/renamed guests, concurrent server fan-out, correct `.unknown` status handling.
- **Siri:** fixed the disambiguation pool falling back to *all* guests (offering already-running guests for Start and reporting a no-op as success); dropped the `INAlternativeAppNames` entry that embedded the real app name. Verified against Apple docs that mixing parameterized/no-parameter phrases on one shortcut is supported (the real limit is multiple parameters per phrase).

## Test plan
- `swift test --package-path Packages/ReeveCore` → 62 tests pass.
- Builds clean: iOS, macOS (verifies `#if os(iOS)` gating of SiriTip/ShortcutsLink), and watch.

## Follow-ups (noted, not in this PR)
- Interactive iOS-26 `SnippetIntent` with inline Start/Stop buttons in the Homelab card.
- Localization via `AppShortcuts.strings`.
- DRY: share the `homelab.serverProfiles` storage key with `ProfileStore`.